### PR TITLE
Need to escape '#'

### DIFF
--- a/ipsecparse/lexer.py
+++ b/ipsecparse/lexer.py
@@ -37,7 +37,7 @@ class Lexer(object):
     t_KEY.__doc__ = r'^[ \t]+' + _name + r'[ \t]*=[ \t]*'
     
     def t_VALUE(self, token):
-        r'([^ \t\n\#"]|(?<=@)#)+'
+        r'([^ \t\n\#"]|(?<=@)\#)+'
         return token
     
     def t_DOUBLE_QUOTED_VALUE(self, token):
@@ -46,7 +46,7 @@ class Lexer(object):
         #  entire value is enclosed in double quotes (");
         #  a value cannot itself contain a double quote, 
         #  nor may it be continued across more than one line."
-        r'"([^"\n\#]|(?<=@)#)*"'
+        r'"([^"\n\#]|(?<=@)\#)*"'
         token.value = token.value[1:-1]
         return token
 


### PR DESCRIPTION
Fixes this problem:
```
In [1]: import ipsecparse
ERROR: /usr/local/lib/python3.7/site-packages/ipsecparse/lexer.py:39: Invalid regular expression for rule 't_VALUE'. missing ), unterminated subpattern at position 12
ERROR: /usr/local/lib/python3.7/site-packages/ipsecparse/lexer.py:39. Make sure '#' in rule 't_VALUE' is escaped with '\#'
ERROR: /usr/local/lib/python3.7/site-packages/ipsecparse/lexer.py:43: Invalid regular expression for rule 't_DOUBLE_QUOTED_VALUE'. missing ), unterminated subpattern at position 27
ERROR: /usr/local/lib/python3.7/site-packages/ipsecparse/lexer.py:43. Make sure '#' in rule 't_DOUBLE_QUOTED_VALUE' is escaped with '\#'
Traceback (most recent call last):

  File "/usr/local/lib/python3.7/site-packages/IPython/core/interactiveshell.py", line 3325, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)

  File "<ipython-input-1-e56d05c7b533>", line 1, in <module>
    import ipsecparse

  File "/usr/local/lib/python3.7/site-packages/ipsecparse/__init__.py", line 37, in <module>
    from ipsecparse.parser import loads

  File "/usr/local/lib/python3.7/site-packages/ipsecparse/parser.py", line 69, in <module>
    loads = Parser().parse

  File "/usr/local/lib/python3.7/site-packages/ipsecparse/parser.py", line 58, in __init__
    lexer = lexer or Lexer()

  File "/usr/local/lib/python3.7/site-packages/ipsecparse/lexer.py", line 64, in __init__
    self.lexer = lex.lex(object = self, debug = 0,reflags = MULTILINE)

  File "/usr/lib/python3.7/site-packages/ply/lex.py", line 910, in lex
    raise SyntaxError("Can't build lexer")

  File "<string>", line unknown
SyntaxError: Can't build lexer
```